### PR TITLE
the function in ping_example_test.go should be a test for the code to…

### DIFF
--- a/ch03/ping_example_test.go
+++ b/ch03/ping_example_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"testing"
 	"time"
 )
 
-func ExamplePinger() {
+func TestExamplePinger(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	r, w := io.Pipe() // in lieu of net.Conn
 	done := make(chan struct{})


### PR DESCRIPTION
As the function `func ExamplePinger()`  from ping_example_test.go stands in the book, no tests are run. I think the  function should be a test (`func TestExamplePinger(t *testing.T)`) for the example to run as described in the book, i.e.

```
go test ping.go ping_example_test.go -v
```